### PR TITLE
feat: Add dark mode theme switching

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -2,10 +2,16 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
-import { Menu, X } from "lucide-react";
+import { Menu, X, Sun, Moon } from "lucide-react";
 import { useAuth } from "@/context/AuthContext";
 import { UserMenu } from "@/components/auth/UserMenu";
-
+import { useTheme } from "@/context/ThemeProvider";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 interface NavbarProps {
   minimal?: boolean;
@@ -20,7 +26,7 @@ const Navbar = ({ minimal = false }: NavbarProps) => {
   };
 
   return (
-    <nav className="bg-white shadow-sm">
+    <nav className="bg-background text-foreground shadow-sm">
       <div className="container mx-auto px-4 py-4">
         <div className="flex justify-between items-center">
           <div className="flex items-center">
@@ -34,11 +40,15 @@ const Navbar = ({ minimal = false }: NavbarProps) => {
               {/* Desktop Navigation */}
               <div className="hidden md:flex items-center space-x-8">
                 <NavLinks />
-                {user ? <UserMenu /> : <AuthButtons />}
+                <div className="flex items-center space-x-4">
+                  {user ? <UserMenu /> : <AuthButtons />}
+                  <ThemeToggle />
+                </div>
               </div>
 
               {/* Mobile menu button */}
-              <div className="md:hidden">
+              <div className="md:hidden flex items-center space-x-2">
+                <ThemeToggle />
                 <Button variant="ghost" size="sm" onClick={toggleMenu} className="p-1">
                   {isMenuOpen ? <X size={24} /> : <Menu size={24} />}
                 </Button>
@@ -66,7 +76,6 @@ const Navbar = ({ minimal = false }: NavbarProps) => {
                 {user ? (
                   <Button
                     onClick={() => {
-
                       signOut();
                       setIsMenuOpen(false);
                     }}
@@ -84,6 +93,33 @@ const Navbar = ({ minimal = false }: NavbarProps) => {
         )}
       </div>
     </nav>
+  );
+};
+
+const ThemeToggle = () => {
+  const { setTheme } = useTheme();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="icon">
+          <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+          <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+          <span className="sr-only">Toggle theme</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => setTheme("light")}>
+          Light
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("dark")}>
+          Dark
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("system")}>
+          System
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 };
 

--- a/src/context/ThemeProvider.tsx
+++ b/src/context/ThemeProvider.tsx
@@ -1,0 +1,73 @@
+import { createContext, useContext, useEffect, useState } from "react"
+
+type Theme = "dark" | "light" | "system"
+
+type ThemeProviderProps = {
+  children: React.ReactNode
+  defaultTheme?: Theme
+  storageKey?: string
+}
+
+type ThemeProviderState = {
+  theme: Theme
+  setTheme: (theme: Theme) => void
+}
+
+const initialState: ThemeProviderState = {
+  theme: "system",
+  setTheme: () => null,
+}
+
+const ThemeProviderContext = createContext<ThemeProviderState>(initialState)
+
+export function ThemeProvider({
+  children,
+  defaultTheme = "system",
+  storageKey = "vite-ui-theme",
+  ...props
+}: ThemeProviderProps) {
+  const [theme, setTheme] = useState<Theme>(
+    () => (localStorage.getItem(storageKey) as Theme) || defaultTheme
+  )
+
+  useEffect(() => {
+    const root = window.document.documentElement
+
+    root.classList.remove("light", "dark")
+
+    if (theme === "system") {
+      const systemTheme = window.matchMedia("(prefers-color-scheme: dark)")
+        .matches
+        ? "dark"
+        : "light"
+
+      root.classList.add(systemTheme)
+      return
+    }
+
+    root.classList.add(theme)
+  }, [theme])
+
+  const value = {
+    theme,
+    setTheme: (theme: Theme) => {
+      localStorage.setItem(storageKey, theme)
+      setTheme(theme)
+    },
+  }
+
+  return (
+    <ThemeProviderContext.Provider {...props} value={value}>
+      {children}
+    </ThemeProviderContext.Provider>
+  )
+}
+
+export const useTheme = () => {
+  const context = useContext(ThemeProviderContext)
+
+  if (context === undefined)
+    throw new Error("useTheme must be used within a ThemeProvider")
+
+  return context
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
-import { SpeedInsights } from "@vercel/speed-insights/react"
 import React from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
+import { ThemeProvider } from './context/ThemeProvider.tsx'
 import './index.css'
 import { injectSpeedInsights } from '@vercel/speed-insights';
 
@@ -12,6 +12,8 @@ const container = document.getElementById("root")
 const root = createRoot(container!)
 root.render(
   <React.StrictMode>
-    <App />
+    <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
+      <App />
+    </ThemeProvider>
   </React.StrictMode>
 )


### PR DESCRIPTION
This commit introduces a dark mode feature to the application.

- A `ThemeProvider` context is created to manage the theme state (`light`, `dark`, `system`) and persist the user's preference in `localStorage`.
- The `ThemeProvider` is integrated into the application's entry point (`src/main.tsx`).
- A `ThemeToggle` component is added to the `Navbar` to allow users to switch between themes.
- The `Navbar` is updated to use theme-aware colors.